### PR TITLE
Exclude generated files from Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.vs
+\[CP\] Stardew Aquarium/config.json

--- a/[CP] Stardew Aquarium/config.json
+++ b/[CP] Stardew Aquarium/config.json
@@ -1,3 +1,0 @@
-{
-  "LegendaryFishAnimation": "true"
-}


### PR DESCRIPTION
The `config.json` file is auto-generated based on the config schema, so it doesn't need to be in source control.