### PR TITLE
Fix incorrect Scorpion Carp special order title

### DIFF
--- a/[CP] Stardew Aquarium/i18n/de.json
+++ b/[CP] Stardew Aquarium/i18n/de.json
@@ -408,7 +408,6 @@
   //Special Order Strings, This Translation was made by CoolRabbit123
   "SA.CrabPot.SOTitle": "Aquarium-Versorgungslauf.",
   "SA.ScorpionCarp.SOTitle": "Zuchtprogramm: Skorpionkarpfen",
-  "SA.ScorpionCarp.SOTitle": "Zuchtprogramm: Oktopus",
   "SA.Stonefish.SOTitle": "Zuchtprogramm: Steinfisch",
   "SA.IcePip.SOTitle": "Zuchtprogramm: Eis-Pip",
   "SA.LavaEel.SOTitle": "Zuchtprogramm: Lava-Aal",

--- a/[CP] Stardew Aquarium/i18n/ru.json
+++ b/[CP] Stardew Aquarium/i18n/ru.json
@@ -414,7 +414,6 @@
   //Special Order Strings
   "SA.CrabPot.SOTitle": "Подача воды в аквариум.",
   "SA.ScorpionCarp.SOTitle": "Программа разведения: Скорпионового карпа",
-  "SA.ScorpionCarp.SOTitle": "Программа разведения: Осьминог",
   "SA.Stonefish.SOTitle": "Программа разведения: Рыба-камень",
   "SA.IcePip.SOTitle": "Программа разведения: Анчоус",
   "SA.LavaEel.SOTitle": "Программа разведения: Лавовый угорь",

--- a/[CP] Stardew Aquarium/i18n/zh.json
+++ b/[CP] Stardew Aquarium/i18n/zh.json
@@ -418,7 +418,6 @@
   //Special Order Strings
   "SA.CrabPot.SOTitle": "水族馆补给任务。",
   "SA.ScorpionCarp.SOTitle": "繁殖计划：蝎子鲤",
-  "SA.ScorpionCarp.SOTitle": "繁殖计划：章鱼",
   "SA.Stonefish.SOTitle": "繁殖计划：石鱼",
   "SA.IcePip.SOTitle": "繁殖计划：冰蜥蜴",
   "SA.LavaEel.SOTitle": "繁殖计划：熔岩鳗",


### PR DESCRIPTION
Some languages incorrectly overrode the 'Breeding: Scorpion Carp' special order's title with a second 'Breeding: Octopus' string.